### PR TITLE
Fix git "unable to clone" error during conda env creation. Fixes #42

### DIFF
--- a/environment-bk.yml
+++ b/environment-bk.yml
@@ -13,5 +13,5 @@ dependencies:
       - streamlit-folium
       - streamlit-keplergl
       - streamlit-bokeh-events
-      - git+git://github.com/giswqs/leafmap
-      - git+git://github.com/giswqs/geemap
+      - git+https://github.com/giswqs/leafmap
+      - git+https://github.com/giswqs/geemap


### PR DESCRIPTION
The fix is similar to an [earlier commit](https://github.com/giswqs/streamlit-geospatial/commit/1160a727977f5cc7f8d36e55e1b28220dab0f578) on the `requirements.txt`. 

Fixes #42.